### PR TITLE
db.override has wrong contents

### DIFF
--- a/data/db.override
+++ b/data/db.override
@@ -1,7 +1,7 @@
 $TTL  86400
 
 @   IN  SOA ns1 root (
-            2015061901  ; serial
+            YYYYMMDD01  ; serial
             604800      ; refresh 1w
             86400       ; retry 1d
             2419200     ; expiry 4w
@@ -9,6 +9,6 @@ $TTL  86400
             )
 
     IN  NS  ns1
-ns1 IN  A   46.101.16.182
-@   IN  A   46.101.16.182
-*   IN  A   46.101.16.182
+ns1 IN  A   127.0.0.1
+@   IN  A   127.0.0.1
+*   IN  A   127.0.0.1


### PR DESCRIPTION
I was just looking at your script and noticed that your current db.override seems to be containing the wrong contents. It should be https://github.com/ab77/netflix-proxy/blob/0c0d7e359cad399350611b8b9ce3ab372a5a7c15/data/db.override for the search & replace in your script to work.