### PR TITLE
Script to generate dnsmasq.conf based on netflix-proxy's zones.override

### DIFF
--- a/dnsmasq-config.py
+++ b/dnsmasq-config.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+
+# Parse domains from BIND config (data/zones.override) and output dnsmasq
+# config file to redirect queries for all of those domains to a given IP
+
+import sys
+
+if len(sys.argv) != 2:
+	print "Usage: ./dnsmasq-config.py <netflix-proxy-ip>"
+	sys.exit(1)
+
+lines = file('data/zones.override').readlines()
+output = 'server='
+
+for line in lines:
+	if line[0:6] == 'zone "':
+		domain = line[6:line.index('."')]
+		output += '/'+domain
+
+output += '/'+sys.argv[1]
+print output


### PR DESCRIPTION
Current output:

$ ./dnsmasq-config.py 1.2.3.4
server=/netflix.com/hulu.com/hbonow.com/hbogo.com/amazon.com/amazon.co.uk/crackle.com/pandora.com/vudu.com/blinkbox.com/tvegolf-i.Akamaihd.net/tvenbcsn-i.Akamaihd.net/abc.com/abc.go.com/fox.com/link.theplatform.com/nbc.com/nbcuni.com/broadband.espn.go.com/ip2location.com/pbs.org/warnerbros.com/southpark.cc.com/ipad-streaming.cbs.com/brightcove.com/cwtv.com/spike.com/go.com/mtv.com/mtvnservices.com/video.dl.playstation.net/uplynk.com/maxmind.com/disney.com/disneyjunior.com/marketplace-xb.xboxlive.com/lovefilm.com/fbchdvod-f.akamaihd.net/turner.com/amctv.com/sho.com/tveusa-vh.akamaihd.net/mog.com/wdtvlive.com/pga-lh.akamaihd.net/beinsportsconnect.tv/beinsportsconnect.net/besmenabs-s.akamaihd.net/besmenaas-s.akamaihd.net/besmenacs-s.akamaihd.net/besmenads-s.akamaihd.net/besmenaes-s.akamaihd.net/besmenafs-s.akamaihd.net/bbc.co.uk/bbci.co.uk/ipinfo.io/1.2.3.4