### PR TITLE
Fix ddns-update script and make sure that PATH exists or it will not work

### DIFF
--- a/scripts/ddns_updater.sh
+++ b/scripts/ddns_updater.sh
@@ -8,6 +8,9 @@
 # bomb on any error
 set -e
 
+# make sure basic paths are set
+export PATH=/sbin:/usr/sbin:/bin:/usr/bin:$PATH
+
 CDW=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 . ${CDW}/functions
 


### PR DESCRIPTION
This will fix problem on certain systems where cron does not export
basic PATH. So, cron will not update IPs because iptables is not
in PATH. For example:

/opt/netflix-proxy/scripts/ddns_updater.sh: line 30: iptables: command not found
/opt/netflix-proxy/scripts/ddns_updater.sh: line 30: iptables-save: command not found