### PR TITLE
Update proxy-domains.txt

### DIFF
--- a/proxy-domains.txt
+++ b/proxy-domains.txt
@@ -70,3 +70,7 @@ sa.bbc.co.uk
 www.bbc.co.uk
 crunchyroll.com
 ifconfig.co
+*.bbc.co.uk
+*.bbc.net.uk
+*.bbc.com
+*.itv.com


### PR DESCRIPTION
Added bbc and itv proxy domains to watch world cup 2018 for free outside UK.